### PR TITLE
add CI workflow for typecheck, lint, and format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check


### PR DESCRIPTION
Fixes #5

Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on pushes to `main` and on pull requests targeting `main`. It runs:

- `npm run typecheck` — TypeScript type checking
- `npm run lint` — ESLint
- `npm run format:check` — Prettier format check