### PR TITLE
use merge-base for branch diff comparison

### DIFF
--- a/src/changedFilesTree.ts
+++ b/src/changedFilesTree.ts
@@ -123,7 +123,7 @@ export class ChangedFilesTreeProvider implements vscode.TreeDataProvider<TreeNod
     return result;
   }
 
-  getTreeItem(element: TreeNode): vscode.TreeItem {
+  async getTreeItem(element: TreeNode): Promise<vscode.TreeItem> {
     if (element.type === "folder") {
       const item = new vscode.TreeItem(element.name, vscode.TreeItemCollapsibleState.Expanded);
       item.iconPath = vscode.ThemeIcon.Folder;
@@ -138,7 +138,7 @@ export class ChangedFilesTreeProvider implements vscode.TreeDataProvider<TreeNod
     const statusChar = STATUS_ICONS[element.change.status] ?? "?";
     item.description = statusChar;
 
-    const action = this.gitService.getFileAction(element.change, this.mode);
+    const action = await this.gitService.getFileAction(element.change, this.mode);
     if (action.type === "diff") {
       item.command = {
         command: "vscode.diff",

--- a/src/gitService.ts
+++ b/src/gitService.ts
@@ -31,6 +31,23 @@ export class GitService {
 
   private stateListener: vscode.Disposable | undefined;
 
+  /**
+   * Resolve a branch name to its remote tracking ref if available.
+   * e.g. "main" → "origin/main" when main tracks origin/main.
+   * Falls back to the original name if no upstream is found.
+   */
+  private async resolveBaseRef(repo: Repository, branchName: string): Promise<string> {
+    try {
+      const branch = await repo.getBranch(branchName);
+      if (branch.upstream) {
+        return `${branch.upstream.remote}/${branch.upstream.name}`;
+      }
+    } catch {
+      // Branch may not exist locally — use as-is
+    }
+    return branchName;
+  }
+
   async initialize(): Promise<boolean> {
     const gitExtension = vscode.extensions.getExtension<GitExtension>("vscode.git");
     if (!gitExtension) {
@@ -84,8 +101,9 @@ export class GitService {
         const baseBranch = vscode.workspace
           .getConfiguration("clext")
           .get<string>("baseBranch", "main");
-        const mergeBase = await repo.getMergeBase(baseBranch, "HEAD");
-        return repo.diffBetween(mergeBase ?? baseBranch, "HEAD");
+        const baseRef = await this.resolveBaseRef(repo, baseBranch);
+        const mergeBase = await repo.getMergeBase(baseRef, "HEAD");
+        return repo.diffBetween(mergeBase ?? baseRef, "HEAD");
       }
     }
   }
@@ -134,8 +152,9 @@ export class GitService {
           .getConfiguration("clext")
           .get<string>("baseBranch", "main");
         const repo = this.getRepository();
-        const mergeBase = repo ? await repo.getMergeBase(baseBranch, "HEAD") : undefined;
-        const baseRef = mergeBase ?? baseBranch;
+        const resolvedBase = repo ? await this.resolveBaseRef(repo, baseBranch) : baseBranch;
+        const mergeBase = repo ? await repo.getMergeBase(resolvedBase, "HEAD") : undefined;
+        const baseRef = mergeBase ?? resolvedBase;
         const left = isAdded ? emptyUri : this.api.toGitUri(change.uri, baseRef);
         const right = this.api.toGitUri(change.uri, "HEAD");
         return { type: "diff", left, right, title: `${filePath} (vs ${baseBranch})` };

--- a/src/gitService.ts
+++ b/src/gitService.ts
@@ -84,18 +84,20 @@ export class GitService {
         const baseBranch = vscode.workspace
           .getConfiguration("clext")
           .get<string>("baseBranch", "main");
-        return repo.diffBetween(baseBranch, "HEAD");
+        const mergeBase = await repo.getMergeBase(baseBranch, "HEAD");
+        return repo.diffBetween(mergeBase ?? baseBranch, "HEAD");
       }
     }
   }
 
-  getFileAction(
+  async getFileAction(
     change: Change,
     mode: DiffMode
-  ):
+  ): Promise<
     | { type: "diff"; left: vscode.Uri; right: vscode.Uri; title: string }
     | { type: "open" }
-    | { type: "message"; text: string } {
+    | { type: "message"; text: string }
+  > {
     if (!this.api) {
       return { type: "open" };
     }
@@ -131,7 +133,10 @@ export class GitService {
         const baseBranch = vscode.workspace
           .getConfiguration("clext")
           .get<string>("baseBranch", "main");
-        const left = isAdded ? emptyUri : this.api.toGitUri(change.uri, baseBranch);
+        const repo = this.getRepository();
+        const mergeBase = repo ? await repo.getMergeBase(baseBranch, "HEAD") : undefined;
+        const baseRef = mergeBase ?? baseBranch;
+        const left = isAdded ? emptyUri : this.api.toGitUri(change.uri, baseRef);
         const right = this.api.toGitUri(change.uri, "HEAD");
         return { type: "diff", left, right, title: `${filePath} (vs ${baseBranch})` };
       }


### PR DESCRIPTION
## Summary

- Use `getMergeBase()` instead of diffing directly against the base branch tip
- This ensures "vs main" mode only shows changes from the current branch, not changes merged into main from other branches
- Falls back to the base branch ref if merge-base is unavailable

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)