### PR TITLE
open new files directly in working changes mode

### DIFF
--- a/src/gitService.ts
+++ b/src/gitService.ts
@@ -132,16 +132,20 @@ export class GitService {
     }
 
     const isAdded = ADDED_STATUSES.has(change.status);
-    const emptyUri = this.api.toGitUri(change.uri, "~");
 
     switch (mode) {
       case DiffMode.Working: {
-        const left = isAdded ? emptyUri : this.api.toGitUri(change.uri, "HEAD");
+        // Untracked/new files don't exist in git, so we can't diff them — just open directly
+        if (isAdded) {
+          return { type: "open" };
+        }
+        const left = this.api.toGitUri(change.uri, "HEAD");
         const right = change.uri;
         return { type: "diff", left, right, title: `${filePath} (Working)` };
       }
 
       case DiffMode.LastCommit: {
+        const emptyUri = this.api.toGitUri(change.uri, "~");
         const left = isAdded ? emptyUri : this.api.toGitUri(change.uri, "HEAD~1");
         const right = this.api.toGitUri(change.uri, "HEAD");
         return { type: "diff", left, right, title: `${filePath} (Last Commit)` };
@@ -155,6 +159,7 @@ export class GitService {
         const resolvedBase = repo ? await this.resolveBaseRef(repo, baseBranch) : baseBranch;
         const mergeBase = repo ? await repo.getMergeBase(resolvedBase, "HEAD") : undefined;
         const baseRef = mergeBase ?? resolvedBase;
+        const emptyUri = this.api.toGitUri(change.uri, "~");
         const left = isAdded ? emptyUri : this.api.toGitUri(change.uri, baseRef);
         const right = this.api.toGitUri(change.uri, "HEAD");
         return { type: "diff", left, right, title: `${filePath} (vs ${baseBranch})` };


### PR DESCRIPTION
## Summary

- In Working Changes mode, clicking a newly created (untracked) file no longer errors. Instead of trying to diff against a non-existent git index ref (`~`), new files are opened directly.
- LastCommit and Branch modes are unaffected — they only show committed files where the index ref resolves correctly.

Fixes #9

## Test plan

- [ ] Create a new untracked file in a repo, switch to Working Changes mode, and click the file — it should open normally
- [ ] Modify an existing tracked file — clicking it should still show a diff as before
- [ ] Verify LastCommit and Branch modes still work for added files

🤖 Generated with [Claude Code](https://claude.com/claude-code)